### PR TITLE
Fix Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var options = {
 
 server.register({
   plugin: Good,
-  options: options
+  register: options
 }, function (err) {
   if (err) {
     return console.error(err);

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ var options = {
 };
 
 server.register({
-  plugin: Good,
-  register: options
+  register: Good,
+  options: options
 }, function (err) {
   if (err) {
     return console.error(err);


### PR DESCRIPTION
The current readme example produces the following error: 
```
        if (plugin.register.register) {                             // Required plugin
                           ^

TypeError: Cannot read property 'register' of undefined
    at module.exports.internals.Plugin.parent.auth.internals.Plugin.register.each [as register] (/Users/patrickcosta/Desktop/eyeball/node_modules/hapi/lib/plugin.js:219:28)
    at Object.<anonymous> (/Users/patrickcosta/Desktop/eyeball/ae.js:24:8)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:142:18)
    at node.js:939:3
```

This commit fixes this problem by renaming the property **plugin** to **register**.